### PR TITLE
Added in a Separate spawner and spawner location for Bears and Racoons

### DIFF
--- a/Content/AI/Animals/BP_Bear.uasset
+++ b/Content/AI/Animals/BP_Bear.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:39bd107b0e9f75f482c417cfd3f8b8cb2e42bc034a0ae41ce4d1c62c9aceb7e3
-size 25801
+oid sha256:95dfdd6b910b78c3d5d304ee9881b1b376a0127bd72519bf3489e113fe9805ca
+size 53699

--- a/Content/AI/Animals/BP_Racoon.uasset
+++ b/Content/AI/Animals/BP_Racoon.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b15563705b3750cdc99fd0ff9a3803fc5c54d80ea2bc84b20b8ba5ebd8ea59fc
-size 25847
+oid sha256:3b66911407a2f50259d64b7668009c26fa25dfdf6e297eecea3fbb42c0ee3d8d
+size 46499

--- a/Content/Levels/SethsMainLevelCopyDontTouch-_-.umap
+++ b/Content/Levels/SethsMainLevelCopyDontTouch-_-.umap
@@ -1,5 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-
-oid sha256:0a9bedbe410c57f38b82e1358118c56d849b5eeb108ef72d13e8430ec1334701
-size 204710108
-
+oid sha256:69262c51e384459bb80b7c7ceee1d4d9fb6c91312c6157c128ec6da92c52942b
+size 204731516


### PR DESCRIPTION
Added in a Separate spawner and spawner location for Bears and Racoons set up a separate nav mesh to show how we are going to separate the individual spawn areas for the animals so that only certain types can spawn in.